### PR TITLE
Log-file-name access to check for presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### Changes
+ - Move definition of kDefaultLogFileParam to public (header). This allows to check whether a log file name was specified via the commandline interface.
+
 ## [9.96.7] - 24-11-2018
 - Adds support for compiling easyloggingpp using Emscripten. This allows the library to be compiled into Javascript or WebAssembly and run in the browser while logging to the browser's Javascript console.
 

--- a/README.md
+++ b/README.md
@@ -479,6 +479,13 @@ Following table will explain all command line arguments that you may use to defi
 | `--logging-flags=3`        | Sets logging flag. In example `i.e, 3`, it sets logging flag to `NewLineForContainer` and `AllowVerboseIfModuleNotSpecified`. See logging flags section above for further details and values. See macros section to disable this function.                                                                   |
 | `--default-log-file=FILE`  |Sets default log file for existing and future loggers. You may want to consider defining `ELPP_NO_DEFAULT_LOG_FILE` to prevent creation of default empty log file during pre-processing. See macros section to disable this function.                                                                           |
 
+You can check whether or not the user specified a file name via `--default-log-file=..` using the following check
+```[c]
+if (el::Helpers::commandLineArgs() != NULL 
+  && el::Helpers::commandLineArgs()->hasParamWithValue(el::base::consts::kDefaultLogFileParam))
+{ ... }
+```
+
  [![top] Goto Top](#table-of-contents)
 
 ### Configuration Macros

--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -98,9 +98,6 @@ static const char* kDefaultLogFile                         =      "myeasylog.log
 #endif // defined(ELPP_NO_DEFAULT_LOG_FILE)
 
 
-#if !defined(ELPP_DISABLE_LOG_FILE_FROM_ARG)
-static const char* kDefaultLogFileParam                    =      "--default-log-file";
-#endif  // !defined(ELPP_DISABLE_LOG_FILE_FROM_ARG)
 #if defined(ELPP_LOGGING_FLAGS_FROM_ARG)
 static const char* kLoggingFlagsParam                      =      "--logging-flags";
 #endif  // defined(ELPP_LOGGING_FLAGS_FROM_ARG)

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -740,6 +740,10 @@ static const char* kDefaultLoggerId                        =      ELPP_DEFAULT_L
 static const char* kDefaultLoggerId                        =      "default";
 #endif
 
+#if !defined(ELPP_DISABLE_LOG_FILE_FROM_ARG)
+static const char* kDefaultLogFileParam                    =      "--default-log-file";
+#endif  // !defined(ELPP_DISABLE_LOG_FILE_FROM_ARG)
+
 #if defined(ELPP_FEATURE_ALL) || defined(ELPP_FEATURE_PERFORMANCE_TRACKING)
 #ifdef ELPP_DEFAULT_PERFORMANCE_LOGGER
 static const char* kPerformanceLoggerId                    =      ELPP_DEFAULT_PERFORMANCE_LOGGER;


### PR DESCRIPTION
### This is a

- [ ] Breaking change
- [x] New feature
- [ ] Bugfix

### I have

- [x] Merged in the latest upstream changes
- [x] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [x] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)

Making the variable `el::base::consts::kDefaultLogFileParam` publicly available via the header enables dedicated logging setups if the user specified the `--default-log-file` command line argument, which is eg needed within my application.
I have added respective documentation to the README.md.

Thanks for consideration!
best,
Martin